### PR TITLE
Update ClipboardTools.cs

### DIFF
--- a/Elinor/ClipboardTools.cs
+++ b/Elinor/ClipboardTools.cs
@@ -41,9 +41,9 @@ namespace Elinor
 
             if (settings.advancedStepSettings)
             {
-                result -= (result*settings.sellPercentage > settings.sellThreshold)
-                              ? settings.sellThreshold
-                              : settings.sellPercentage*result;
+                result -= (result - result*settings.sellPercentage) > settings.sellThreshold
+                              ? (result - result*settings.sellPercentage)
+                              : settings.sellThreshold;
             }
             else
             {
@@ -61,9 +61,9 @@ namespace Elinor
 
             if (settings.advancedStepSettings)
             {
-                result += result*settings.buyPercentage > settings.buyThreshold
-                              ? settings.buyThreshold
-                              : settings.buyPercentage*result;
+                result += (result - result*settings.buyPercentage) > settings.buyThreshold
+                              ? (result - result*settings.buyPercentage)
+                              : settings.buyThreshold;
             }
             else
             {


### PR DESCRIPTION
https://github.com/Slivo-fr/elinor-reloaded/blob/ccc8b4dd3ba365a5cb8cb2961b008f9040739a41/Elinor/ClipboardTools.cs#L44

If you look at ClipboardTools line 44 and line 64, you can see what is wrong with increment.

Someone tried to be crafty, but I think their logic is wrong. 

`result` is the variable the holds the price (I think). 

Normally, `result` is just result -= 0.01 or += 0.01. Recently, Eve has changed the minimum price differential to be +/- 4 significant figures of the price.

SO, this is where advanced increment settings comes in. 

If sell price fraction is 99, we expect the price of something selling for 10,000 to be copied as 9900. But this won't happen.

The code checks 10,000 * 99 (I guess this has already been converted to 0.99). Then it checks whether this new price is greater than the threshold. But the new price is a price not a differential on price. So being above a threshold will basically always evaluate to true. 

Then once this evaluates to true, the wrong item is returned by the ternary operator, the threshold is returned. 

This is what I think it should be, and here's a PR if you're around to re-release it. I can't test it easily as I run linux and already have issues running things with wine/ don't know how C# works. I will test it if I hear back from you and it's too much for you to test it.

I wrote this with the idea that the feature should always use sell price fraction except when that would lead to less of a price difference than threshold. The new equality checks whether the sellPercentage amount is a greater differential than threshold. If it is, this amount is used. If it's not, then the threshold is used.

Line 44:
`result -= (result - result*settings.sellPercentage) > settings.sellThreshold
                              ? (result - result*settings.sellPercentage)
                              : settings.sellThreshold;`

Line 64:
`result += (result - result*settings.buyPercentage) > settings.buyThreshold
                              ? (result - result*settings.buyPercentage)
                              : settings.buyThreshold;`
